### PR TITLE
Fix CDN link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Lisk JS is a JavaScript library for [Lisk - the cryptocurrency and blockchain ap
 
 ## CDN
 
-https://gitcdn.xyz/repo/LiskHQ/lisk-js/development/dist/lisk-js.js<br/>
+https://gitcdn.xyz/repo/LiskHQ/lisk-js/master/dist/lisk-js.js<br/>
 ```html
-<script src="https://gitcdn.xyz/repo/LiskHQ/lisk-js/development/dist/lisk-js.js"></script>
+<script src="https://gitcdn.xyz/repo/LiskHQ/lisk-js/master/dist/lisk-js.js"></script>
 ```
 
 ## Server


### PR DESCRIPTION
Link to CDN for lisk-js was broken, possibly because it was pointing to the development branch rather than master branch.